### PR TITLE
Clear navigation node parameters before updating with new parameters

### DIFF
--- a/Pod/Sources/VSPNavigationNode.m
+++ b/Pod/Sources/VSPNavigationNode.m
@@ -113,9 +113,7 @@
 }
 
 - (void)updateParametersRecursively:(NSDictionary *)parameters {
-    NSMutableDictionary *newParamters = [self.parameters mutableCopy];
-    [newParamters addEntriesFromDictionary:parameters];
-    self.parameters = newParamters;
+    self.parameters = parameters;
     [self.child updateParametersRecursively:parameters];
 }
 


### PR DESCRIPTION
@minhtule Please review.

Currently, when we navigate between different URLs, parameters that are not explicitly overwritten will be retained in the navigation tree. For example:

Navigate from:
`/stores/123456&category=789` (node path is `root -> tabs -> tab -> store`)
to:
`/tabs` (node path is `root -> tabs`)

After navigation, the `root` and `tabs` nodes will still have the parameters:

```
{
  'store_id': 123456,
  'category': 789
}
```

This causes some interesting behaviors, from benign to outright fatal, such as if we navigate to a store's category via a deeplink (which sets the `category` parameter) and then navigate to a different store, the app crashes as it tries to find the same category ID under a different store.
